### PR TITLE
PILOT-4192 Store UUID of auth flows

### DIFF
--- a/api/v1/keycloakauthflow_types.go
+++ b/api/v1/keycloakauthflow_types.go
@@ -20,6 +20,11 @@ type KeycloakAuthFlowSpec struct {
 	// Alias is display name for authentication flow.
 	Alias string `json:"alias"`
 
+	// UUID for authentication flow.
+	// +nullable
+	// +optional
+	UUID string `json:"uuid"`
+
 	// Description is description for authentication flow.
 	// +optional
 	Description string `json:"description,omitempty"`

--- a/config/crd/bases/v1.edp.epam.com_keycloakauthflows.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakauthflows.yaml
@@ -116,6 +116,10 @@ spec:
               topLevel:
                 description: TopLevel is true if this is root auth flow.
                 type: boolean
+              uuid:
+                description: UUID for authentication flow.
+                nullable: true
+                type: string
             required:
             - alias
             - builtIn

--- a/controllers/keycloakauthflow/keycloakauthflow_controller.go
+++ b/controllers/keycloakauthflow/keycloakauthflow_controller.go
@@ -131,6 +131,7 @@ func (r *Reconcile) Reconcile(ctx context.Context, request reconcile.Request) (r
 }
 
 func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.KeycloakAuthFlow) error {
+	log := ctrl.LoggerFrom(ctx)
 	if err := r.helper.SetRealmOwnerRef(ctx, instance); err != nil {
 		return fmt.Errorf("unable to set realm owner ref: %w", err)
 	}
@@ -161,8 +162,12 @@ func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.Keyc
 		return nil
 	}
 
-	if err := kClient.SyncAuthFlow(gocloak.PString(realm.Realm), keycloakAuthFlow); err != nil {
+	log.Info("Syncing KeycloakAuthFlow with Keycloak")
+	if id, err := kClient.SyncAuthFlow(gocloak.PString(realm.Realm), keycloakAuthFlow); err != nil {
 		return fmt.Errorf("unable to sync auth flow: %w", err)
+	} else {
+		log.Info("Adding UUID from Keycloak to KeycloakAuthFlow spec: " + id)
+		instance.Spec.UUID = id
 	}
 
 	return nil

--- a/controllers/keycloakauthflow/keycloakauthflow_controller.go
+++ b/controllers/keycloakauthflow/keycloakauthflow_controller.go
@@ -168,6 +168,9 @@ func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.Keyc
 	} else {
 		log.Info("Adding UUID from Keycloak to KeycloakAuthFlow spec: " + id)
 		instance.Spec.UUID = id
+		if err := r.client.Update(ctx, instance); err != nil {
+			return fmt.Errorf("Failed to update KeycloakAuthFlow UUID in spec: %w", err)
+		}
 	}
 
 	return nil

--- a/controllers/keycloakauthflow/keycloakauthflow_controller_test.go
+++ b/controllers/keycloakauthflow/keycloakauthflow_controller_test.go
@@ -75,7 +75,7 @@ func TestNewReconcile(t *testing.T) {
 	kClient.On("SyncAuthFlow", realm.Spec.RealmName, &adapter.KeycloakAuthFlow{
 		Alias:                    flow.Spec.Alias,
 		AuthenticationExecutions: []adapter.AuthenticationExecution{},
-	}).Return(nil)
+	}).Return("", nil)
 
 	h.On("TryToDelete", testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything).
 		Return(false, nil)
@@ -146,7 +146,7 @@ func TestReconcile_Reconcile_Failure(t *testing.T) {
 	kClient.On("SyncAuthFlow", realm.Spec.RealmName, &adapter.KeycloakAuthFlow{
 		Alias:                    flow.Spec.Alias,
 		AuthenticationExecutions: []adapter.AuthenticationExecution{},
-	}).Return(mockErr)
+	}).Return("", mockErr)
 
 	r := Reconcile{
 		helper: h,
@@ -213,7 +213,7 @@ func TestReconcile_Reconcile_FailureToGetParentRealm(t *testing.T) {
 	kClient.On("SyncAuthFlow", realm.Spec.RealmName, &adapter.KeycloakAuthFlow{
 		Alias:                    flow.Spec.Alias,
 		AuthenticationExecutions: []adapter.AuthenticationExecution{},
-	}).Return(mockErr)
+	}).Return("", mockErr)
 
 	r := Reconcile{
 		helper: h,

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakauthflows.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakauthflows.yaml
@@ -116,6 +116,10 @@ spec:
               topLevel:
                 description: TopLevel is true if this is root auth flow.
                 type: boolean
+              uuid:
+                description: UUID for authentication flow.
+                nullable: true
+                type: string
             required:
             - alias
             - builtIn

--- a/docs/api.md
+++ b/docs/api.md
@@ -3397,6 +3397,13 @@ KeycloakAuthFlowSpec defines the desired state of KeycloakAuthFlow.
           RealmRef is reference to Realm custom resource.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>uuid</b></td>
+        <td>string</td>
+        <td>
+          UUID for authentication flow.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow.go
@@ -103,7 +103,7 @@ func (a GoCloakAdapter) DeleteAuthFlow(realmName string, flow *KeycloakAuthFlow)
 func (a GoCloakAdapter) SyncAuthFlow(realmName string, flow *KeycloakAuthFlow) (string, error) {
 	id, err := a.syncBaseAuthFlow(realmName, flow)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to sync base auth flow")
+		return id, errors.Wrap(err, "unable to sync base auth flow")
 	}
 
 	sort.Sort(orderByPriority(flow.AuthenticationExecutions))

--- a/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow.go
@@ -100,10 +100,10 @@ func (a GoCloakAdapter) DeleteAuthFlow(realmName string, flow *KeycloakAuthFlow)
 	return nil
 }
 
-func (a GoCloakAdapter) SyncAuthFlow(realmName string, flow *KeycloakAuthFlow) error {
+func (a GoCloakAdapter) SyncAuthFlow(realmName string, flow *KeycloakAuthFlow) (string, error) {
 	id, err := a.syncBaseAuthFlow(realmName, flow)
 	if err != nil {
-		return errors.Wrap(err, "unable to sync base auth flow")
+		return "", errors.Wrap(err, "unable to sync base auth flow")
 	}
 
 	sort.Sort(orderByPriority(flow.AuthenticationExecutions))
@@ -115,15 +115,15 @@ func (a GoCloakAdapter) SyncAuthFlow(realmName string, flow *KeycloakAuthFlow) e
 
 		e.ParentFlow = id
 		if err := a.addAuthFlowExecution(realmName, &e); err != nil {
-			return errors.Wrap(err, "unable to add auth execution")
+			return id, errors.Wrap(err, "unable to add auth execution")
 		}
 	}
 
 	if err := a.adjustChildFlowsPriority(realmName, flow); err != nil {
-		return errors.Wrap(err, "unable to adjust child flow priority")
+		return id, errors.Wrap(err, "unable to adjust child flow priority")
 	}
 
-	return nil
+	return id, nil
 }
 
 func (a GoCloakAdapter) adjustChildFlowsPriority(realmName string, flow *KeycloakAuthFlow) error {
@@ -337,6 +337,7 @@ func (a GoCloakAdapter) createAuthFlow(realmName string, flow *KeycloakAuthFlow)
 		return "", errors.Wrap(err, "unable to create auth flow in realm")
 	}
 
+	// Get UUID of created flow from Keycloak response
 	id, err = getIDFromResponseLocation(resp.RawResponse)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get flow id")

--- a/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow_test.go
@@ -148,7 +148,7 @@ func (e *ExecFlowTestSuite) TestSyncAuthFlow() {
 		httpmock.NewStringResponder(200, ""),
 	)
 
-	err := e.adapter.SyncAuthFlow(e.realmName, &flow)
+	_, err := e.adapter.SyncAuthFlow(e.realmName, &flow)
 	assert.NoError(e.T(), err)
 }
 

--- a/pkg/client/keycloak/adapter/mock.go
+++ b/pkg/client/keycloak/adapter/mock.go
@@ -212,8 +212,12 @@ func (m *Mock) DeleteAuthFlow(realmName string, flow *KeycloakAuthFlow) error {
 	return m.Called(realmName, flow).Error(0)
 }
 
-func (m *Mock) SyncAuthFlow(realmName string, flow *KeycloakAuthFlow) error {
-	return m.Called(realmName, flow).Error(0)
+func (m *Mock) SyncAuthFlow(realmName string, flow *KeycloakAuthFlow) (string, error) {
+	called := m.Called(realmName, flow)
+	if err := called.Error(1); err != nil {
+		return "", err
+	}
+	return called.String(0), nil
 }
 
 func (m *Mock) SetRealmBrowserFlow(realmName string, flowAlias string) error {

--- a/pkg/client/keycloak/keycloak_client.go
+++ b/pkg/client/keycloak/keycloak_client.go
@@ -46,7 +46,7 @@ type KIdentityProvider interface {
 }
 
 type KAuthFlow interface {
-	SyncAuthFlow(realmName string, flow *adapter.KeycloakAuthFlow) error
+	SyncAuthFlow(realmName string, flow *adapter.KeycloakAuthFlow) (string, error)
 	DeleteAuthFlow(realmName string, flow *adapter.KeycloakAuthFlow) error
 	SetRealmBrowserFlow(realmName string, flowAlias string) error
 }


### PR DESCRIPTION
## Summary

- Add `UUID` to `KeycloakAuthFlowSpec`.
- When reconciling a `KeycloakAuthFlow`, get the UUID that Keycloak uses to uniquely identify each auth flow and save it to the object's spec.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-4192

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

Create a new `KeycloakAuthFlow` object. After the first reconcile, its spec should have a `UUID` set automatically.